### PR TITLE
Fixes working directory absolute path for source files in lcov

### DIFF
--- a/src/parse/parse-lcov.js
+++ b/src/parse/parse-lcov.js
@@ -12,7 +12,7 @@ function getCoverageFromLine(line) {
     return line.slice(3).split(',').map(number => Number(number));
 }
 
-function convertLcovSectionToCoverallsSourceFile(lcovSection, projectRoot) {
+function convertLcovSectionToCoverallsSourceFile(lcovSection, workingDirectory) {
     const lcovSectionLines = lcovSection.trim().split('\n'),
         coverallsSourceFile = {
             coverage: []
@@ -22,10 +22,10 @@ function convertLcovSectionToCoverallsSourceFile(lcovSection, projectRoot) {
 
     lcovSectionLines.forEach(line => {
         if (line.startsWith('SF:')) {
-            const absoluteFilePath = line.slice(3),
+            const absoluteFilePath = path.join(workingDirectory, line.slice(3)),
                 fileSource = getSourceFromFile(absoluteFilePath);
 
-            coverallsSourceFile.name = getRelativeFilePath(absoluteFilePath, projectRoot);
+            coverallsSourceFile.name = getRelativeFilePath(absoluteFilePath, workingDirectory);
             coverallsSourceFile.source_digest = getSourceDigest(fileSource);
 
             numberOfSourceFileLines = getNumberOfLinesInSource(fileSource);
@@ -59,7 +59,7 @@ export default (reportFile, config) => new Promise(resolve => {
         lcovSections = lcovContents.split('end_of_record\n'),
         result = lcovSections
             .filter(emptySections)
-            .map(section => convertLcovSectionToCoverallsSourceFile(section, config.projectRoot));
+            .map(section => convertLcovSectionToCoverallsSourceFile(section, config.workingDirectory));
 
     resolve(result);
 });


### PR DESCRIPTION
I was having trouble getting the `workingDirectory` for the source files working which I when I spotted that it wasn't being used